### PR TITLE
Add animate functions to Springable protocol

### DIFF
--- a/Spring/Spring.swift
+++ b/Spring/Spring.swift
@@ -45,6 +45,11 @@ import UIKit
     var layer : CALayer { get }
     var transform : CGAffineTransform { get set }
     var alpha : CGFloat { get set }
+    
+    func animate()
+    func animateNext(completion: () -> ())
+    func animateTo()
+    func animateToNext(completion: () -> ())
 }
 
 public class Spring : NSObject {


### PR DESCRIPTION
Hi, I have added:

```swift
    func animate()
    func animateNext(completion: () -> ())
    func animateTo()
    func animateToNext(completion: () -> ())
```

to *Springable* protocol so it's possible to do use Generics like:

```swift
    private func pop<T: Springable>(view: T){
        view.animation = "pop"
        view.animate()
    }

    
    private func fadeOut<T: Springable>(view: T){
        view.animation = "fadeOut"
        view.animate()
    }
    
    private func fadeIn<T: Springable>(view: T){
        view.animation = "fadeIn"
        view.animate()
    }
```
