### PR TITLE
Delete extraneous imports Spring

### DIFF
--- a/Spring/AsyncButton.swift
+++ b/Spring/AsyncButton.swift
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 import UIKit
-import Spring
 
 public class AsyncButton: UIButton {
 

--- a/Spring/AsyncImageView.swift
+++ b/Spring/AsyncImageView.swift
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 import UIKit
-import Spring
 
 public class AsyncImageView: UIImageView {
 


### PR DESCRIPTION
They prevent building Spring by dragging the files into your Xcode project, because that won't make a module called Spring. And they shouldn't be needed to build the pod. Unless I'm missing something?