### PR TITLE
Allow user interaction.

### DIFF
--- a/Spring/Spring.swift
+++ b/Spring/Spring.swift
@@ -476,7 +476,7 @@ public class Spring : NSObject {
             delay: NSTimeInterval(delay),
             usingSpringWithDamping: damping,
             initialSpringVelocity: velocity,
-            options: getAnimationOptions(curve),
+            options: getAnimationOptions(curve) | UIViewAnimationOptions.AllowUserInteraction,
             animations: { [weak self] in
             if let _self = self
             {


### PR DESCRIPTION
This closes #66.
This only allows user interactions during an UIView animation. CAAnimations need hit testing. (see #66)