### PR TITLE
Feature/objc spring animation

### DIFF
--- a/Spring/LoadingView.swift
+++ b/Spring/LoadingView.swift
@@ -60,7 +60,7 @@ public extension UIView {
         self.addSubview(loadingXibView)
 
         loadingXibView.alpha = 0
-        spring(0.7, {
+        SpringAnimation.spring(0.7, animations: {
             loadingXibView.alpha = 1
         })
     }
@@ -70,10 +70,10 @@ public extension UIView {
         if let loadingXibView = self.viewWithTag(LoadingViewConstants.Tag) {
             loadingXibView.alpha = 1
 
-            springWithCompletion(0.7, {
+            SpringAnimation.springWithCompletion(0.7, animations: {
                 loadingXibView.alpha = 0
                 loadingXibView.transform = CGAffineTransformMakeScale(3, 3)
-            }, { (completed) -> Void in
+            }, completion: { (completed) -> Void in
                 loadingXibView.removeFromSuperview()
             })
         }

--- a/Spring/SpringAnimation.swift
+++ b/Spring/SpringAnimation.swift
@@ -22,106 +22,108 @@
 
 import UIKit
 
-public func spring(duration: NSTimeInterval, animations: (() -> Void)!) {
-    
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        usingSpringWithDamping: 0.7,
-        initialSpringVelocity: 0.7,
-        options: nil,
-        animations: {
+public class SpringAnimation {
+    public class func spring(duration: NSTimeInterval, animations: (() -> Void)!) {
+
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            usingSpringWithDamping: 0.7,
+            initialSpringVelocity: 0.7,
+            options: nil,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springEaseIn(duration: NSTimeInterval, animations: (() -> Void)!) {
+
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            options: UIViewAnimationOptions.CurveEaseIn,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springEaseOut(duration: NSTimeInterval, animations: (() -> Void)!) {
+
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            options: UIViewAnimationOptions.CurveEaseOut,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springEaseInOut(duration: NSTimeInterval, animations: (() -> Void)!) {
+
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            options: UIViewAnimationOptions.CurveEaseInOut,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springLinear(duration: NSTimeInterval, animations: (() -> Void)!) {
+
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            options: UIViewAnimationOptions.CurveLinear,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springWithDelay(duration: NSTimeInterval, delay: NSTimeInterval, animations: (() -> Void)!) {
+        UIView.animateWithDuration(
+            duration,
+            delay: delay,
+            usingSpringWithDamping: 0.7,
+            initialSpringVelocity: 0.7,
+            options: nil,
+            animations: {
+
+                animations()
+
+            }, completion: { finished in
+        })
+    }
+
+    public class func springWithCompletion(duration: NSTimeInterval, animations: (() -> Void)!, completion: ((Bool) -> Void)!) {
         
-            animations()
-        
-        }, completion: { finished in
-    })
-}
-
-public func springEaseIn(duration: NSTimeInterval, animations: (() -> Void)!) {
-    
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        options: UIViewAnimationOptions.CurveEaseIn,
-        animations: {
-            
-            animations()
-            
-        }, completion: { finished in
-    })
-}
-
-public func springEaseOut(duration: NSTimeInterval, animations: (() -> Void)!) {
-    
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        options: UIViewAnimationOptions.CurveEaseOut,
-        animations: {
-            
-            animations()
-            
-        }, completion: { finished in
-    })
-}
-
-public func springEaseInOut(duration: NSTimeInterval, animations: (() -> Void)!) {
-    
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        options: UIViewAnimationOptions.CurveEaseInOut,
-        animations: {
-            
-            animations()
-            
-        }, completion: { finished in
-    })
-}
-
-public func springLinear(duration: NSTimeInterval, animations: (() -> Void)!) {
-    
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        options: UIViewAnimationOptions.CurveLinear,
-        animations: {
-            
-            animations()
-            
-        }, completion: { finished in
-    })
-}
-
-public func springWithDelay(duration: NSTimeInterval, delay: NSTimeInterval, animations: (() -> Void)!) {
-    UIView.animateWithDuration(
-        duration,
-        delay: delay,
-        usingSpringWithDamping: 0.7,
-        initialSpringVelocity: 0.7,
-        options: nil,
-        animations: {
-            
-            animations()
-            
-        }, completion: { finished in
-    })
-}
-
-public func springWithCompletion(duration: NSTimeInterval, animations: (() -> Void)!, completion: ((Bool) -> Void)!) {
-
-    UIView.animateWithDuration(
-        duration,
-        delay: 0,
-        usingSpringWithDamping: 0.7,
-        initialSpringVelocity: 0.7,
-        options: nil,
-        animations: {
-        
-            animations()
-        
-        }, completion: { finished in
-            completion(true)
-    })
+        UIView.animateWithDuration(
+            duration,
+            delay: 0,
+            usingSpringWithDamping: 0.7,
+            initialSpringVelocity: 0.7,
+            options: nil,
+            animations: {
+                
+                animations()
+                
+            }, completion: { finished in
+                completion(true)
+        })
+    }
 }

--- a/Spring/SpringAnimation.swift
+++ b/Spring/SpringAnimation.swift
@@ -22,7 +22,7 @@
 
 import UIKit
 
-public class SpringAnimation {
+@objc public class SpringAnimation {
     public class func spring(duration: NSTimeInterval, animations: (() -> Void)!) {
 
         UIView.animateWithDuration(

--- a/Spring/SpringAnimation.swift
+++ b/Spring/SpringAnimation.swift
@@ -110,7 +110,7 @@ import UIKit
         })
     }
 
-    public class func springWithCompletion(duration: NSTimeInterval, animations: (() -> Void)!, completion: ((Bool) -> Void)!) {
+    public class func springWithCompletion(duration: NSTimeInterval, animations: (() -> Void)!, completion: (Bool -> Void)!) {
         
         UIView.animateWithDuration(
             duration,
@@ -123,7 +123,8 @@ import UIKit
                 animations()
                 
             }, completion: { finished in
-                completion(true)
-        })
+                completion(finished)
+            }
+        )
     }
 }

--- a/Spring/TransitionManager.swift
+++ b/Spring/TransitionManager.swift
@@ -37,7 +37,7 @@ public class TransitionManager: NSObject, UIViewControllerTransitioningDelegate,
             toView.transform = CGAffineTransformMakeTranslation(0, container.frame.size.height)
             container.addSubview(fromView)
             container.addSubview(toView)
-            springEaseInOut(duration) {
+            SpringAnimation.springEaseInOut(duration) {
                 fromView.transform = CGAffineTransformMakeScale(0.8, 0.8)
                 fromView.alpha = 0.5
                 toView.transform = CGAffineTransformIdentity
@@ -58,7 +58,7 @@ public class TransitionManager: NSObject, UIViewControllerTransitioningDelegate,
             container.addSubview(toView)
             container.addSubview(fromView)
 
-            springEaseInOut(duration) {
+            SpringAnimation.springEaseInOut(duration) {
                 fromView.transform = CGAffineTransformMakeTranslation(0, fromView.frame.size.height)
                 toView.transform = CGAffineTransformIdentity
                 toView.alpha = 1

--- a/Spring/TransitionZoom.swift
+++ b/Spring/TransitionZoom.swift
@@ -38,7 +38,8 @@ public class TransitionZoom: NSObject, UIViewControllerTransitioningDelegate, UI
             
             toView.alpha = 0
             toView.transform = CGAffineTransformMakeScale(2, 2)
-            springEaseInOut(duration) {
+
+            SpringAnimation.springEaseInOut(duration) {
                 fromView.transform = CGAffineTransformMakeScale(0.5, 0.5)
                 fromView.alpha = 0
                 toView.transform = CGAffineTransformIdentity
@@ -49,7 +50,7 @@ public class TransitionZoom: NSObject, UIViewControllerTransitioningDelegate, UI
             container.addSubview(toView)
             container.addSubview(fromView)
             
-            springEaseInOut(duration) {
+            SpringAnimation.springEaseInOut(duration) {
                 fromView.transform = CGAffineTransformMakeScale(2, 2)
                 fromView.alpha = 0
                 toView.transform = CGAffineTransformMakeScale(1, 1)

--- a/SpringApp/SpringViewController.swift
+++ b/SpringApp/SpringViewController.swift
@@ -103,14 +103,14 @@ class SpringViewController: UIViewController, UIPickerViewDelegate, UIPickerView
     }
     
     func minimizeView(sender: AnyObject) {
-        spring(0.7, {
+        SpringAnimation.spring(0.7, animations: {
             self.view.transform = CGAffineTransformMakeScale(0.935, 0.935)
         })
         UIApplication.sharedApplication().setStatusBarStyle(UIStatusBarStyle.LightContent, animated: true)
     }
     
     func maximizeView(sender: AnyObject) {
-        spring(0.7, {
+        SpringAnimation.spring(0.7, animations: {
             self.view.transform = CGAffineTransformMakeScale(1, 1)
         })
         UIApplication.sharedApplication().setStatusBarStyle(UIStatusBarStyle.Default, animated: true)


### PR DESCRIPTION
This pull request closes #94 and also resolves #72 and doesn't need code duplication just for Obj-C (#95).

I moved all first class functions to a class, which makes it Objective-C compatible for Mix and Match.
With this change we now have to write `SpringAnimation.spring(12, animations: ...)` – Which I think is even cleaner than using first class functions.