### PR TITLE
Fix keyboard layout constraint for attached hardware keyboard.

### DIFF
--- a/Spring/KeyboardLayoutConstraint.swift
+++ b/Spring/KeyboardLayoutConstraint.swift
@@ -45,8 +45,12 @@ public class KeyboardLayoutConstraint: NSLayoutConstraint {
     func keyboardWillShowNotification(notification: NSNotification) {
         if let userInfo = notification.userInfo {
             if let frameValue = userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue {
-                let frame = frameValue.CGRectValue()
-                keyboardVisibleHeight = frame.size.height
+                let keyboardRect = frameValue.CGRectValue()
+                let screenRect = UIScreen.mainScreen().bounds
+                
+                let intersectionRect = CGRectIntersection(keyboardRect, screenRect)
+                
+                keyboardVisibleHeight = intersectionRect.size.height
             }
 
             self.updateConstant()


### PR DESCRIPTION
The `UIKeyboardFrameEndUserInfoKey` must be intersected with the screen coordinates. 
Otherwise the keyboard frame may be off screen when an external keyboard is attached.
See: http://stackoverflow.com/a/29330392
