### PR TITLE
Changed Spring initializer from `internal` to `public`.

### DIFF
--- a/Spring/Spring.swift
+++ b/Spring/Spring.swift
@@ -58,7 +58,7 @@ public class Spring : NSObject {
     private var shouldAnimateAfterActive = false
     private var shouldAnimateInLayoutSubviews = true
     
-    init(_ view: Springable) {
+    public init(_ view: Springable) {
         self.view = view
         super.init()
         commonInit()


### PR DESCRIPTION
I changed the access modifier for the initializer of the Spring class from `internal` (default) to `public`. This change was made because if you were using Carthage and building Spring as a dynamic framework, you couldn't make your own Classes to conform to the Springable protocol. since you couldn't initialize a Spring object from outside the framework.