### PR TITLE
Fixed C-style syntax

### DIFF
--- a/Spring/AutoTextView.swift
+++ b/Spring/AutoTextView.swift
@@ -18,7 +18,7 @@ public class AutoTextView: UITextView {
                 size.height = 0
             }
             
-            contentInset = UIEdgeInsetsMake(-4, -4, -4, -4)
+            contentInset = UIEdgeInsets(top: -4, left: -4, bottom: -4, right: -4)
             layoutIfNeeded()
             
             return size

--- a/Spring/DesignableTextField.swift
+++ b/Spring/DesignableTextField.swift
@@ -89,8 +89,8 @@ import UIKit
             paragraphStyle.lineSpacing = lineHeight
             
             let attributedString = NSMutableAttributedString(string: text!)
-            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
-            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSMakeRange(0, attributedString.length))
+            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSRange(location: 0, length: attributedString.length))
             
             self.attributedText = attributedString
         }

--- a/Spring/DesignableTextView.swift
+++ b/Spring/DesignableTextView.swift
@@ -49,10 +49,10 @@ import UIKit
             
             let paragraphStyle = NSMutableParagraphStyle()
             paragraphStyle.lineSpacing = lineHeight
-            
+
             let attributedString = NSMutableAttributedString(string: text!)
-            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSMakeRange(0, attributedString.length))
-            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSMakeRange(0, attributedString.length))
+            attributedString.addAttribute(NSParagraphStyleAttributeName, value: paragraphStyle, range: NSRange(location: 0, length: attributedString.length))
+            attributedString.addAttribute(NSFontAttributeName, value: font!, range: NSRange(location: 0, length: attributedString.length))
             
             self.attributedText = attributedString
         }


### PR DESCRIPTION
Hi. I fixed following C-style syntax.
- `UIEdgeInsetsMake()`
- `NSMakeRange()`

These method is non-labels and non-Swift-like syntax. Swift-like syntax is clarity and intuitive. Therefore, we should clearly indicate a label and role.
So, I used `struct initializer` in place of `non-labels argument function`.  
Actually, `CGRectMake` , `CGPointMake`, `CGSizeMake` etc is unavailable in `Swift3.`
