### PR TITLE
Update SoundPlayer.swift

### DIFF
--- a/Spring/SoundPlayer.swift
+++ b/Spring/SoundPlayer.swift
@@ -23,7 +23,7 @@
 import UIKit
 import AudioToolbox
 
-struct SoundPlayer {
+public struct SoundPlayer {
     
     static var filename : String?
     static var enabled : Bool = true
@@ -32,7 +32,7 @@ struct SoundPlayer {
         static var cache = [URL:SystemSoundID]()
     }
     
-    static func playSound(soundFile: String) {
+    public static func playSound(soundFile: String) {
         
         if !enabled {
             return


### PR DESCRIPTION
Issue #217 details this problem. It isn’t possible to use SoundPlayer unless these are public