### PR TITLE
Fix compile error in DesignableTabBarController

### DIFF
--- a/Spring/DesignableTabBarController.swift
+++ b/Spring/DesignableTabBarController.swift
@@ -27,20 +27,20 @@ import UIKit
     @IBInspectable var normalTint: UIColor = UIColor.clear {
         didSet {
             UITabBar.appearance().tintColor = normalTint
-            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor.rawValue: normalTint], for: UIControlState())
+            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor: normalTint], for: UIControlState())
         }
     }
     
     @IBInspectable var selectedTint: UIColor = UIColor.clear {
         didSet {
             UITabBar.appearance().tintColor = selectedTint
-            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor.rawValue: selectedTint], for:UIControlState.selected)
+            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor: selectedTint], for:UIControlState.selected)
         }
     }
     
     @IBInspectable var fontName: String = "" {
         didSet {
-            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor.rawValue: normalTint, NSAttributedStringKey.font.rawValue: UIFont(name: fontName, size: 11)!], for: UIControlState())
+            UITabBarItem.appearance().setTitleTextAttributes([NSAttributedStringKey.foregroundColor: normalTint, NSAttributedStringKey.font: UIFont(name: fontName, size: 11)!], for: UIControlState())
         }
     }
     


### PR DESCRIPTION
I've got following error on Xcode 9 beta 4. And fixed it.

```
Cannot convert value of type 'String' to expected dictionary key type 'NSAttributedStringKey'
```