### PR TITLE
Allow this to work inside tab view controllers

### DIFF
--- a/Spring/KeyboardLayoutConstraint.swift
+++ b/Spring/KeyboardLayoutConstraint.swift
@@ -27,6 +27,8 @@ public class KeyboardLayoutConstraint: NSLayoutConstraint {
     private var offset : CGFloat = 0
     private var keyboardVisibleHeight : CGFloat = 0
     
+   @IBInspectable var inTabViewController: Bool = false
+    
     override public func awakeFromNib() {
         super.awakeFromNib()
         
@@ -101,6 +103,9 @@ public class KeyboardLayoutConstraint: NSLayoutConstraint {
     
     func updateConstant() {
         self.constant = offset + keyboardVisibleHeight
+        if inTabViewController && keyboardVisibleHeight != 0 { // if typing in tab view controller
+            constant -= 49
+        }
     }
     
 }


### PR DESCRIPTION
How? If the view will appear in a view controller that will use a tab bar, enable the "inTabViewController" inspector
attribute to prevent issues

Why? A view anchored to the top of a tab bar has its position compromised because the tab view animates downwards when the keyboard appears. This position, where the top of the tab bar is at the bottom of the visible screen results in a view that is slightly hidden by the tab bar. 

More briefly, when the tab bar animates away, the topOffset is the distance to the bottom of the screen and not to the top of tab bar.