### PR TITLE
fix warnings

### DIFF
--- a/Spring/Misc.swift
+++ b/Spring/Misc.swift
@@ -23,7 +23,7 @@
 import UIKit
 
 public extension String {
-    public var length: Int { return self.characters.count }
+    public var length: Int { return self.count }
     
     public func toURL() -> NSURL? {
         return NSURL(string: self)
@@ -73,7 +73,7 @@ public extension UIColor {
         let scanner = Scanner(string: hex)
         var hexValue: CUnsignedLongLong = 0
         if scanner.scanHexInt64(&hexValue) {
-            switch (hex.characters.count) {
+            switch (hex.count) {
             case 3:
                 red   = CGFloat((hexValue & 0xF00) >> 8)       / 15.0
                 green = CGFloat((hexValue & 0x0F0) >> 4)       / 15.0


### PR DESCRIPTION
fix ``` 'characters' is deprecated: Please use String or Substring directly``` warnings in Swift 4