### PR TITLE
Add basic SwiftPM manifest file

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,16 @@
+// swift-tools-version:4.2
+import PackageDescription
+
+let package = Package(
+    name: "Spring",
+    // platforms: [.iOS("8.0"), tvOS("11.0")],
+    products: [
+        .library(name: "Spring", targets: ["Spring"])
+    ],
+    targets: [
+        .target(
+            name: "Spring",
+            path: "Spring"
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ use_frameworks!
 pod 'Spring', :git => 'https://github.com/MengTo/Spring.git'
 ```
 
+Or via [Accio](https://github.com/JamitLabs/Accio):
+```swift
+.package(url: "https://github.com/MengTo/Spring.git", .upToNextMajor(from: "1.0.5")),
+```
+
 ## Usage with Storyboard
 In Identity Inspector, connect the UIView to SpringView Class and set the animation properties in Attribute Inspector.
 


### PR DESCRIPTION
This adds support for SwiftPM manifest based dependency managers. Specifically this adds support for installing via [Accio](https://github.com/JamitLabs/Accio) but will probably also work with SwiftPM once it's integrated into Xcode.

Please note that this project is part of Accio's official [integration tests](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo/Shared/AppDependencies) within the [Demo project](https://github.com/JamitLabs/Accio/tree/work/1000-frameworks/Demo).