### PR TITLE
Fix redundant `public` statements and prefer `let` over `var`

### DIFF
--- a/Spring/DesignableTabBarController.swift
+++ b/Spring/DesignableTabBarController.swift
@@ -47,7 +47,7 @@ import UIKit
     @IBInspectable var firstSelectedImage: UIImage? {
         didSet {
             if let image = firstSelectedImage {
-                var tabBarItems = self.tabBar.items as [UITabBarItem]?
+                let tabBarItems = self.tabBar.items as [UITabBarItem]?
                 tabBarItems?[0].selectedImage = image.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
             }
         }
@@ -56,7 +56,7 @@ import UIKit
     @IBInspectable var secondSelectedImage: UIImage? {
         didSet {
             if let image = secondSelectedImage {
-                var tabBarItems = self.tabBar.items as [UITabBarItem]?
+                let tabBarItems = self.tabBar.items as [UITabBarItem]?
                 tabBarItems?[1].selectedImage = image.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
             }
         }
@@ -65,7 +65,7 @@ import UIKit
     @IBInspectable var thirdSelectedImage: UIImage? {
         didSet {
             if let image = thirdSelectedImage {
-                var tabBarItems = self.tabBar.items as [UITabBarItem]?
+                let tabBarItems = self.tabBar.items as [UITabBarItem]?
                 tabBarItems?[2].selectedImage = image.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
             }
         }
@@ -74,7 +74,7 @@ import UIKit
     @IBInspectable var fourthSelectedImage: UIImage? {
         didSet {
             if let image = fourthSelectedImage {
-                var tabBarItems = self.tabBar.items as [UITabBarItem]?
+                let tabBarItems = self.tabBar.items as [UITabBarItem]?
                 tabBarItems?[3].selectedImage = image.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
             }
         }
@@ -83,7 +83,7 @@ import UIKit
     @IBInspectable var fifthSelectedImage: UIImage? {
         didSet {
             if let image = fifthSelectedImage {
-                var tabBarItems = self.tabBar.items as [UITabBarItem]?
+                let tabBarItems = self.tabBar.items as [UITabBarItem]?
                 tabBarItems?[4].selectedImage = image.withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
             }
         }

--- a/Spring/LoadingView.swift
+++ b/Spring/LoadingView.swift
@@ -50,7 +50,7 @@ public extension UIView {
         static let Tag = 1000
     }
 
-    public func showLoading() {
+    func showLoading() {
 
         if self.viewWithTag(LoadingViewConstants.Tag) != nil {
             // If loading view is already found in current view hierachy, do nothing
@@ -68,7 +68,7 @@ public extension UIView {
         })
     }
 
-    public func hideLoading() {
+    func hideLoading() {
 
         if let loadingXibView = self.viewWithTag(LoadingViewConstants.Tag) {
             loadingXibView.alpha = 1

--- a/Spring/UnwindSegue.swift
+++ b/Spring/UnwindSegue.swift
@@ -23,5 +23,5 @@
 import UIKit
 
 public extension UIViewController {
-    @IBAction public func unwindToViewController (_ segue: UIStoryboardSegue){}
+    @IBAction func unwindToViewController (_ segue: UIStoryboardSegue){}
 }


### PR DESCRIPTION
This should resolve unnecessary compiler warnings over "reduntant public declaration" or "use `let` instead of `var` for non-mutating variables".